### PR TITLE
Rename namespace which runs nyamber-runner

### DIFF
--- a/config/dev/namespaces.yaml
+++ b/config/dev/namespaces.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: nyamber-pod
+  name: nyamber-runner

--- a/e2e/manifests/namespace.yaml
+++ b/e2e/manifests/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: nyamber-pod
+  name: nyamber-runner
 
 ---
 apiVersion: v1

--- a/e2e/manifests/script-config/kustomization.yaml
+++ b/e2e/manifests/script-config/kustomization.yaml
@@ -3,7 +3,7 @@ generatorOptions:
 
 configMapGenerator:
 - name: scripts
-  namespace: nyamber-pod
+  namespace: nyamber-runner
   files:
    - scripts/neco-bootstrap
    - scripts/neco-apps-bootstrap

--- a/e2e/vdc_test.go
+++ b/e2e/vdc_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Nyamber vdc e2e test", func() {
 		for _, tt := range testcases {
 			By(tt.name)
 			Eventually(func() (*corev1.Pod, error) {
-				out, err := kubectl(nil, "get", "pod", "-n", "nyamber-pod", tt.name, "-o", "json")
+				out, err := kubectl(nil, "get", "pod", "-n", "nyamber-runner", tt.name, "-o", "json")
 				if err != nil {
 					return nil, err
 				}
@@ -105,7 +105,7 @@ var _ = Describe("Nyamber vdc e2e test", func() {
 				})),
 			)
 			Eventually(func() error {
-				_, err := kubectl(nil, "get", "svc", "-n", "nyamber-pod", tt.name)
+				_, err := kubectl(nil, "get", "svc", "-n", "nyamber-runner", tt.name)
 				if err != nil {
 					return err
 				}
@@ -135,7 +135,7 @@ var _ = Describe("Nyamber vdc e2e test", func() {
 		for _, tt := range testcases {
 			By(tt.name)
 			Eventually(func() ([]string, error) {
-				out, err := kubectl(nil, "logs", "-n", "nyamber-pod", tt.name)
+				out, err := kubectl(nil, "logs", "-n", "nyamber-runner", tt.name)
 				if err != nil {
 					return nil, err
 				}
@@ -209,14 +209,14 @@ var _ = Describe("Nyamber vdc e2e test", func() {
 		for _, v := range vdcs {
 			By(v)
 			Eventually(func() error {
-				_, err := kubectl(nil, "get", "pod", "-n", "nyamber-pod", v)
+				_, err := kubectl(nil, "get", "pod", "-n", "nyamber-runner", v)
 				if err != nil {
 					return err
 				}
 				return nil
 			}).Should(HaveOccurred())
 			Eventually(func() error {
-				_, err := kubectl(nil, "get", "svc", "-n", "nyamber-pod", v)
+				_, err := kubectl(nil, "get", "svc", "-n", "nyamber-runner", v)
 				if err != nil {
 					return err
 				}

--- a/pkg/constants/resources.go
+++ b/pkg/constants/resources.go
@@ -2,6 +2,6 @@ package constants
 
 const ControllerNamespace = "nyamber"
 
-const PodNamespace = "nyamber-pod"
+const PodNamespace = "nyamber-runner"
 
 const PodTemplateName = "nyamber-pod-template"


### PR DESCRIPTION
Rename nyamber-pod namespace to nyamber-runner
Because the name nyamber-pod is difficult to understand.

Signed-off-by: yamatcha <soju-yamashita@cybozu.co.jp>