### PR TITLE
Add labels of app.kubernetes.io/name and app.kubernetes.io/component

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: nyamber
+    app.kubernetes.io/component: controller
   name: system
 ---
 apiVersion: apps/v1
@@ -11,18 +12,21 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: nyamber
+    app.kubernetes.io/component: controller
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: nyamber
+      app.kubernetes.io/component: controller
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        app.kubernetes.io/name: nyamber
+        app.kubernetes.io/component: controller
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: nyamber
+    app.kubernetes.io/component: controller
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +18,5 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+    app.kubernetes.io/name: nyamber
+    app.kubernetes.io/component: controller

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: nyamber
+    app.kubernetes.io/component: controller
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -12,4 +13,5 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: nyamber
+    app.kubernetes.io/component: controller

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -10,4 +10,5 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: nyamber
+    app.kubernetes.io/component: controller

--- a/controllers/virtualdc_controller.go
+++ b/controllers/virtualdc_controller.go
@@ -160,6 +160,9 @@ func (r *VirtualDCReconciler) createPod(ctx context.Context, vdc *nyamberv1beta1
 		Name:      vdc.Name,
 		Namespace: r.PodNamespace,
 		Labels: map[string]string{
+			constants.AppNameLabelKey:        constants.AppName,
+			constants.AppComponentLabelKey:   constants.AppComponentRunner,
+			constants.AppInstanceLabelKey:    vdc.Name,
 			constants.LabelKeyOwnerNamespace: vdc.Namespace,
 			constants.LabelKeyOwner:          vdc.Name,
 		},

--- a/controllers/virtualdc_controller_test.go
+++ b/controllers/virtualdc_controller_test.go
@@ -172,6 +172,9 @@ spec:
 			return k8sClient.Get(ctx, client.ObjectKey{Name: "test-vdc", Namespace: testPodNamespace}, pod)
 		}).Should(Succeed())
 		Expect(pod.Labels).To(MatchAllKeys(Keys{
+			constants.AppNameLabelKey:        Equal(constants.AppName),
+			constants.AppComponentLabelKey:   Equal(constants.AppComponentRunner),
+			constants.AppInstanceLabelKey:    Equal(vdc.Name),
 			constants.LabelKeyOwnerNamespace: Equal(testNamespace),
 			constants.LabelKeyOwner:          Equal("test-vdc"),
 		}))

--- a/pkg/constants/meta.go
+++ b/pkg/constants/meta.go
@@ -9,3 +9,23 @@ const (
 )
 
 const FinalizerName = MetaPrefix + "finalizer"
+
+// Metadata keys
+const (
+	// AppNameLabelKey is a label key for application name.
+	AppNameLabelKey = "app.kubernetes.io/name"
+
+	// AppComponentLabelKey is a label key for the component.
+	AppComponentLabelKey = "app.kubernetes.io/component"
+
+	// AppInstanceLabelKey is a label key for the instance name.
+	AppInstanceLabelKey = "app.kubernetes.io/instance"
+)
+
+const (
+	// AppName is the application name.
+	AppName = "nyamber"
+
+	// AppComponentRunner is the component name for runner.
+	AppComponentRunner = "runner"
+)


### PR DESCRIPTION
Add `app.kubernetes.io/name` and `app.kubernetes.io/component` labels for nyamber-runner pod and nyamber-controller.