### PR TITLE
Refer avdc creationTimestamp when next start time is nil

### DIFF
--- a/controllers/autovirtualdc_controller.go
+++ b/controllers/autovirtualdc_controller.go
@@ -218,7 +218,13 @@ func (r *AutoVirtualDCReconciler) reconcileVirtualDC(ctx context.Context, avdc *
 		}
 
 		now := r.Now()
-		if now.After(avdc.Status.NextStartTime.Time.Add(timeoutDuration)) {
+		var startTime time.Time
+		if avdc.Status.NextStartTime == nil {
+			startTime = avdc.CreationTimestamp.Time
+		} else {
+			startTime = avdc.Status.NextStartTime.Time
+		}
+		if now.After(startTime.Add(timeoutDuration)) {
 			logger.Info("requeue after next stop-time because timeout has passed.")
 			return ctrl.Result{RequeueAfter: r.Sub(avdc.Status.NextStopTime.Time, now)}, nil
 		}

--- a/controllers/autovirtualdc_controller.go
+++ b/controllers/autovirtualdc_controller.go
@@ -218,13 +218,10 @@ func (r *AutoVirtualDCReconciler) reconcileVirtualDC(ctx context.Context, avdc *
 		}
 
 		now := r.Now()
-		var startTime time.Time
-		if avdc.Status.NextStartTime == nil {
-			startTime = avdc.CreationTimestamp.Time
-		} else {
-			startTime = avdc.Status.NextStartTime.Time
-		}
-		if now.After(startTime.Add(timeoutDuration)) {
+		if avdc.Status.NextStartTime == nil && now.After(avdc.CreationTimestamp.Time.Add(timeoutDuration)) {
+			logger.Info("don't requeue because timeout has passed.")
+			return ctrl.Result{}, nil
+		} else if avdc.Status.NextStartTime != nil && now.After(avdc.Status.NextStartTime.Time.Add(timeoutDuration)) {
 			logger.Info("requeue after next stop-time because timeout has passed.")
 			return ctrl.Result{RequeueAfter: r.Sub(avdc.Status.NextStopTime.Time, now)}, nil
 		}

--- a/controllers/autovirtualdc_controller_test.go
+++ b/controllers/autovirtualdc_controller_test.go
@@ -656,7 +656,7 @@ var _ = Describe("AutoVirtualDC controller", func() {
 	})
 
 	It("should operate VDC according to TimeoutDuration of AVDC when startSchedule/stopSchedule is not set", func() {
-		By("creating AutoVirtualDC between startTime and stopTime")
+		By("creating AutoVirtualDC")
 		clock.SetTime(time.Date(2000, 1, 1, 1, 0, 0, 0, time.UTC))
 		avdc := &nyamberv1beta1.AutoVirtualDC{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
When startSchedule is not set, nextStartTime will be nil.
Nyamber controller retries runner pod by comparing nextStarTime with the current Time, and controller is fault by nil pointer exception.
In this PR, controller would retry runner pod by comparing creationTimestamp of avdc with the current Time.