### PR TITLE
Validate avdc template when startSchedule is not set

### DIFF
--- a/hooks/autovirtualdc.go
+++ b/hooks/autovirtualdc.go
@@ -22,6 +22,7 @@ import (
 
 	nyamberv1beta1 "github.com/cybozu-go/nyamber/api/v1beta1"
 	"github.com/robfig/cron"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -94,6 +95,11 @@ func (v autoVirtualdcValidator) ValidateUpdate(ctx context.Context, oldObj, newO
 
 	oldSpec := oldObj.(*nyamberv1beta1.AutoVirtualDC).Spec
 	newSpec := newObj.(*nyamberv1beta1.AutoVirtualDC).Spec
+
+	// If avdc.Spec.StartSchedule is not set, vdc template is immutable
+	if avdc.Spec.StartSchedule == "" && !equality.Semantic.DeepEqual(oldSpec, newSpec) {
+		errs = append(errs, field.Forbidden(field.NewPath("spec", "template"), "the field is immutable"))
+	}
 
 	if oldSpec.StartSchedule != newSpec.StartSchedule {
 		errs = append(errs, field.Forbidden(field.NewPath("spec", "startSchedule"), "the field is immutable"))

--- a/hooks/autovirtualdc_test.go
+++ b/hooks/autovirtualdc_test.go
@@ -157,6 +157,18 @@ var _ = Describe("AutoVirtualDC validator", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should not be allowed to update template in AutoVirtualDC resources when Schedule is not set", func() {
+		avdc := makeAutoVirtualDC()
+		avdc.Spec.StartSchedule = ""
+		avdc.Spec.StopSchedule = ""
+		err := k8sClient.Create(ctx, avdc)
+		Expect(err).NotTo(HaveOccurred())
+		By("updating vdc template")
+		avdc.Spec.Template.Spec.NecoBranch = "hoge"
+		err = k8sClient.Update(ctx, avdc)
+		Expect(err).To(HaveOccurred())
+	})
+
 	It("should deny autoVirtualDC resources if the name of the autoVirtualDC conflicts with one of VirtualDC resources", func() {
 		vdc := &nyamberv1beta1.VirtualDC{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Changes to avdc are reflected in the vdc when the vdc is recreated.
But if `startSchedule` is not set, vdc is only created once.
In this PR, vdc template in avdc is immutable if `startSchedule` is not set.