### PR TITLE
install lsb-release package to runner container image explicitly

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -66,6 +66,7 @@ RUN apt-get update \
             iproute2 \
             openssh-client \
             sudo \
+            lsb-release \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sSLf https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /usr/local -xzf - \
     && curl -sfL https://github.com/cybozu-go/placemat/releases/download/v${PLACEMAT_VERSION}/placemat2_${PLACEMAT_VERSION}_amd64.deb -o placemat2_${PLACEMAT_VERSION}_amd64.deb \


### PR DESCRIPTION
Some of Neco's system use `lsb_release` command to check the environment such as distro version. The runner container image currently lacks `lsb-release` package, which includes `lsb_release` command.

cf. https://github.com/cybozu-go/neco/blob/release-2023.05.29-22887/installer/Makefile#L21

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>