### PR TITLE
bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Integrate version management into aqua ([#74](https://github.com/cybozu-go/nyamber/pull/74))
 - Bump dependencies version ([#77](https://github.com/cybozu-go/nyamber/pull/77))
 
-## [0.8.0] - 2026-1-14
+## [0.8.0] - 2026-01-14
 
 - Bump supported kubernetes from 1.33 to 1.34 ([#70](https://github.com/cybozu-go/nyamber/pull/70))
 - Bump dependencies version ([#69](https://github.com/cybozu-go/nyamber/pull/69))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-15
+
+- Introduce Renovate for automated dependency updates ([#73](https://github.com/cybozu-go/nyamber/pull/73))
+- Integrate version management into aqua ([#74](https://github.com/cybozu-go/nyamber/pull/74))
+- Bump dependencies version ([#77](https://github.com/cybozu-go/nyamber/pull/77))
+
 ## [0.8.0] - 2026-1-14
 
 - Bump supported kubernetes from 1.33 to 1.34 ([#70](https://github.com/cybozu-go/nyamber/pull/70))
@@ -106,7 +112,8 @@ This fixes git vulnerabilities
 
 - This is the first public release.
 
-[Unreleased]: https://github.com/cybozu-go/nyamber/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/cybozu-go/nyamber/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/cybozu-go/nyamber/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/cybozu-go/nyamber/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/cybozu-go/nyamber/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/cybozu-go/nyamber/compare/v0.6.0...v0.6.1


### PR DESCRIPTION
## Changes since v0.8.0

- Introduce Renovate for automated dependency updates (#73)
- Integrate version management into aqua (#74)
- Bump dependencies version (#77)


## What this PR does

Updates CHANGELOG.md and bumps the version to 0.9.0.

Previous release PR: #72

