### PR TITLE
Fix gitignore to ignore bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@
 /.idea
 
 # Generated files
+/bin
 /tmp-charts
 /docs/book


### PR DESCRIPTION
In #81, I updated `.gitignore` to ignore `/tmp-charts` instead of `/bin`

But, we should still ignore `/bin` for binaries generated by `make build`.
https://github.com/cybozu-go/nyamber/blob/065fb08fe900d664b2ac85a7e986efdc50d0707c/Makefile#L6
https://github.com/cybozu-go/nyamber/blob/065fb08fe900d664b2ac85a7e986efdc50d0707c/Makefile#L92

