### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-12
+
+- Verify checksum and digest pinning for external binaries ([#81](https://github.com/cybozu-go/nyamber/pull/81))
+- Add github token permissions in workflow ([#82](https://github.com/cybozu-go/nyamber/pull/82))
+- Bump supported kubernetes from 1.34 to 1.35 ([#83](https://github.com/cybozu-go/nyamber/pull/83))
+
 ## [0.9.0] - 2026-04-15
 
 - Introduce Renovate for automated dependency updates ([#73](https://github.com/cybozu-go/nyamber/pull/73))
@@ -112,7 +118,8 @@ This fixes git vulnerabilities
 
 - This is the first public release.
 
-[Unreleased]: https://github.com/cybozu-go/nyamber/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/cybozu-go/nyamber/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/cybozu-go/nyamber/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/cybozu-go/nyamber/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/cybozu-go/nyamber/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/cybozu-go/nyamber/compare/v0.6.1...v0.7.0


### PR DESCRIPTION
Bump version to 0.10.0

Previous release PR: #80

## Compare links

- Before creating tag `v0.10.0`: [v0.9.0...HEAD](https://github.com/cybozu-go/nyamber/compare/v0.9.0...HEAD)
- After creating tag `v0.10.0`: [v0.9.0...v0.10.0](https://github.com/cybozu-go/nyamber/compare/v0.9.0...v0.10.0)