### PR TITLE
update: 26/06

### DIFF
--- a/.github/actions/aqua/action.yaml
+++ b/.github/actions/aqua/action.yaml
@@ -1,0 +1,16 @@
+name: Setup aqua
+description: Install aqua and tools
+inputs:
+  aqua_version:
+    description: aqua version to install
+    required: true
+  github_token:
+    description: GitHub token
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+      with:
+        aqua_version: ${{ inputs.aqua_version }}
+        github_token: ${{ inputs.github_token }}

--- a/.github/actions/aqua/action.yaml
+++ b/.github/actions/aqua/action.yaml
@@ -6,3 +6,5 @@ runs:
     - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
       with:
         aqua_version: v2.59.1 # renovate: aquaproj/aqua
+      env:  
+        GITHUB_TOKEN: ${{ github.token }}  

--- a/.github/actions/aqua/action.yaml
+++ b/.github/actions/aqua/action.yaml
@@ -1,16 +1,8 @@
 name: Setup aqua
 description: Install aqua and tools
-inputs:
-  aqua_version:
-    description: aqua version to install
-    required: true
-  github_token:
-    description: GitHub token
-    required: true
 runs:
   using: composite
   steps:
     - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
       with:
-        aqua_version: ${{ inputs.aqua_version }}
-        github_token: ${{ inputs.github_token }}
+        aqua_version: v2.59.1 # renovate: aquaproj/aqua

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
     - run: make logs
       working-directory: e2e
       if: always()
-    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: logs-${{ steps.k8s-version.outputs.version }}.tar.gz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,6 @@ jobs:
       with:
         go-version-file: go.mod
     - uses: ./.github/actions/aqua
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
     - run: make fmt
     - run: make vet
     - run: make check-generate
@@ -44,8 +42,6 @@ jobs:
       with:
         go-version-file: go.mod
     - uses: ./.github/actions/aqua
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Extract kubernetes version from kind-image-ref
       id: k8s-version
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ jobs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
-    - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c  # v4.0.4
+    - uses: ./.github/actions/aqua
       with:
-        aqua_version: v2.57.1
+        aqua_version: v2.59.1
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - run: make fmt
     - run: make vet
@@ -44,9 +44,9 @@ jobs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: go.mod
-    - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c  # v4.0.4
+    - uses: ./.github/actions/aqua
       with:
-        aqua_version: v2.57.1
+        aqua_version: v2.59.1
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Extract kubernetes version from kind-image-ref
       id: k8s-version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,6 @@ jobs:
         go-version-file: go.mod
     - uses: ./.github/actions/aqua
       with:
-        aqua_version: v2.59.1
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - run: make fmt
     - run: make vet
@@ -46,7 +45,6 @@ jobs:
         go-version-file: go.mod
     - uses: ./.github/actions/aqua
       with:
-        aqua_version: v2.59.1
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Extract kubernetes version from kind-image-ref
       id: k8s-version

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -13,7 +13,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/setup-aqua
+      - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+        with:
+          aqua_version: v2.57.1
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify SHAs and tag comments are consistent
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -2,9 +2,8 @@ name: Pinact
 on:
   pull_request:
     paths:
-      - '.github/**'
-      - 'aqua.yaml'
-      - 'aqua-checksums.json'
+      - '.github/**/*.yml'
+      - '.github/**/*.yaml'
 jobs:
   verify-pinact:
     name: Verify pinned GitHub Actions comments
@@ -13,9 +12,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+      - uses: ./.github/actions/aqua
         with:
-          aqua_version: v2.57.1
+          aqua_version: v2.59.1
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify SHAs and tag comments are consistent
         env:

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -12,10 +12,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: ./.github/actions/aqua
         with:
-          aqua_version: v2.59.1
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+      - uses: ./.github/actions/aqua
       - name: Verify SHAs and tag comments are consistent
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -1,0 +1,21 @@
+name: Pinact
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+      - 'aqua.yaml'
+      - 'aqua-checksums.json'
+jobs:
+  verify-pinact:
+    name: Verify pinned GitHub Actions comments
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/setup-aqua
+      - name: Verify SHAs and tag comments are consistent
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pinact run --check --verify-comment

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,10 +14,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - run: make docker-build
       - name: Login to ghcr.io
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
@@ -20,7 +20,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@68a3ea99af6ad249940b5a9fdf44fc6d7f14378b # renovate v46.1.6
+        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           configurationFile: config.json
           token: ${{ steps.app-token.outputs.token }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build the manager binary
-FROM ghcr.io/cybozu/golang:1.26.2.2_jammy@sha256:ce7b7016908ee9bebefd48aa18106cadf3e7d7ac6150b8e789726cda3cc9beae AS builder
+# Nyamber depends on cybozu-go/placemat. Since cybozu-go/placemat does not support Ubuntu 24.04 yet, use a jammy-based image.
+FROM ghcr.io/cybozu/golang:1.26.4.1_jammy@sha256:4273ab54d46bc2018b65785354589f6af6995c42b71c290b702035f2defa088d AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -19,7 +20,8 @@ COPY pkg/ pkg/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/nyamber-controller/main.go
 
-FROM ghcr.io/cybozu/ubuntu:22.04.20260422@sha256:465d53037c713b03e2d84bdec49903513b50da16eebfd06d3ca9aaa12bff4407
+# Nyamber depends on cybozu-go/placemat. Since cybozu-go/placemat does not support Ubuntu 24.04 yet, use a jammy-based image.
+FROM ghcr.io/cybozu/ubuntu:22.04.20260605@sha256:2ec1363fa00398af0f13a5baa6c84d3245615de7ad576c498fe3c739fd06076e
 LABEL org.opencontainers.image.source=https://github.com/cybozu-go/nyamber
 
 WORKDIR /

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -1,5 +1,6 @@
 # Build the manager binary
-FROM ghcr.io/cybozu/golang:1.26.2.2_jammy@sha256:ce7b7016908ee9bebefd48aa18106cadf3e7d7ac6150b8e789726cda3cc9beae AS builder
+# Nyamber depends on cybozu-go/placemat. Since cybozu-go/placemat does not support Ubuntu 24.04 yet, use a jammy-based image.
+FROM ghcr.io/cybozu/golang:1.26.4.1_jammy@sha256:4273ab54d46bc2018b65785354589f6af6995c42b71c290b702035f2defa088d AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -18,15 +19,16 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o entrypoint cmd/entrypoint/main.go
 
-FROM ghcr.io/cybozu/ubuntu:22.04.20260422@sha256:465d53037c713b03e2d84bdec49903513b50da16eebfd06d3ca9aaa12bff4407
+# Nyamber depends on cybozu-go/placemat. Since cybozu-go/placemat does not support Ubuntu 24.04 yet, use a jammy-based image.
+FROM ghcr.io/cybozu/ubuntu:22.04.20260605@sha256:2ec1363fa00398af0f13a5baa6c84d3245615de7ad576c498fe3c739fd06076e
 LABEL org.opencontainers.image.source=https://github.com/cybozu-go/nyamber
 
 # renovate: datasource=golang-version depName=go
-ENV GO_VERSION=1.26.2
-ENV GO_SHA=990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282
+ENV GO_VERSION=1.26.4
+ENV GO_SHA=1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f
 # renovate: datasource=github-releases depName=cybozu-go/placemat
-ENV PLACEMAT_VERSION=2.4.10
-ENV PLACEMAT_SHA=4c2660c1377c7860c31b5f0a6f89a1878e81c665c281a3ebdc4da8ccd60082ff
+ENV PLACEMAT_VERSION=2.4.11
+ENV PLACEMAT_SHA=eb32893ed824d8d009cd7214283c02b9652a460fa3a7184c47e7adbcc0f32cd2
 
 ENV HOME=/home/nyamber
 ENV GOPATH=${HOME}/go

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ Nyamber is a custom controller to create Neco environment
 This repository uses [pinact](https://github.com/suzuki-shunsuke/pinact) to update and verify pinned GitHub Actions.
 
 ```shell
-$ GITHUB_TOKEN="$(gh auth token)" pinact run --update --min-age 14
+GITHUB_TOKEN="$(gh auth token)" pinact run --update --min-age 14
 ```

--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ Nyamber is a custom controller to create Neco environment
 [docs](docs/) directory contains documents about designs and specifications.
 
 [releases]: https://github.com/cybozu-go/nyamber/releases
+
+### Update pinned GitHub Actions
+
+This repository uses [pinact](https://github.com/suzuki-shunsuke/pinact) to update and verify pinned GitHub Actions.
+
+```shell
+$ GITHUB_TOKEN="$(gh auth token)" pinact run --update --min-age 14
+```

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -136,6 +136,26 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/mikefarah/yq/v4.53.3/yq_darwin_amd64",
+      "checksum": "B4BA1ECCE3C47F00803F4F964DE38394326C7A32EB6540616E04FB2935A0F08D",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/mikefarah/yq/v4.53.3/yq_darwin_arm64",
+      "checksum": "877DE31753A4DD2401AA048937AA9A7FC4D5F6CE858CF31508C5802954297213",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/mikefarah/yq/v4.53.3/yq_linux_amd64",
+      "checksum": "FA52A4E758C63D38299163FBDD1EDFB4C4963247918BF9C1C5D31D84789EDED4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/mikefarah/yq/v4.53.3/yq_linux_arm64",
+      "checksum": "578648E463A11C1B6DB6010CBF41EAFED6BEE79466FCFFA1BB446672CF7945EA",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/tilt-dev/ctlptl/v0.9.0/ctlptl.0.9.0.linux.arm64.tar.gz",
       "checksum": "77813732235DF15BB1749EB09B128AAD439D43E1998756C62DC159535A3032DA",
       "algorithm": "sha256"
@@ -156,6 +176,26 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/tilt-dev/ctlptl/v0.9.4/ctlptl.0.9.4.linux.arm64.tar.gz",
+      "checksum": "2F079D3A80FEAC892B83C5FD842445D879DDC6B0E640021CF5FF604E21337050",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/ctlptl/v0.9.4/ctlptl.0.9.4.linux.x86_64.tar.gz",
+      "checksum": "C63A1EC28E60BC3FAF6BECB76F53355C5CF5E0143DAFDD27AD85DB5584FA6B1E",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/ctlptl/v0.9.4/ctlptl.0.9.4.mac.arm64.tar.gz",
+      "checksum": "5DD227ED5E29E110B1A887E3CADBF8DB29514C9447D6E128E9D59F3CFB39490B",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/ctlptl/v0.9.4/ctlptl.0.9.4.mac.x86_64.tar.gz",
+      "checksum": "2596555A136A5FEABD32DD6D1569BDEE3C9A85CDF84904F60CD4C37E97227FAC",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/tilt-dev/tilt/v0.37.0/tilt.0.37.0.linux.arm64.tar.gz",
       "checksum": "84457137539D8E4BE6E90E9AFECF8EF692AD3F8C19E9BF3355F3FBF4F8DCE55F",
       "algorithm": "sha256"
@@ -173,6 +213,26 @@
     {
       "id": "github_release/github.com/tilt-dev/tilt/v0.37.0/tilt.0.37.0.mac.x86_64.tar.gz",
       "checksum": "01C5E53921345ED4FEB3BA6BC9585F8F5563E40BEA27DAE0384620D5BBC2EBEA",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/tilt/v0.37.3/tilt.0.37.3.linux.arm64.tar.gz",
+      "checksum": "826F48198F368EF5EDB684E9AE4C87FF76ECA84C904F72B2376B29B93BFFC019",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/tilt/v0.37.3/tilt.0.37.3.linux.x86_64.tar.gz",
+      "checksum": "E90BC6CF70882BC7579D8174A27CAB2DE0284612EC7339E4B32F669CD5DE4E5C",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/tilt/v0.37.3/tilt.0.37.3.mac.arm64.tar.gz",
+      "checksum": "4D1F4E604AA5CA65A2DF0D19C9E9B351CF9703BE886F52FA5F3AFD317D968FFD",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/tilt/v0.37.3/tilt.0.37.3.mac.x86_64.tar.gz",
+      "checksum": "C8E2B58FB7EFDEC9AE7E3FC4249B4F662DC6520EABE8EFCAC84B80856F20D31B",
       "algorithm": "sha256"
     },
     {
@@ -216,9 +276,34 @@
       "algorithm": "sha256"
     },
     {
+      "id": "http/get.helm.sh/helm-v4.2.0-darwin-amd64.tar.gz",
+      "checksum": "1376EA697140E4DB316736E760D5A47D12AFC1524DCE704476EF06FD7FDEDDC6",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/get.helm.sh/helm-v4.2.0-darwin-arm64.tar.gz",
+      "checksum": "F13F959015447B6BC309F9FD506509926543988A39035C088B52522EC95E2ACB",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/get.helm.sh/helm-v4.2.0-linux-amd64.tar.gz",
+      "checksum": "97DBEB971BE4AC4B27E3839976D9564C0FB35C6F3B1DA89DD1E292D236AF4096",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/get.helm.sh/helm-v4.2.0-linux-arm64.tar.gz",
+      "checksum": "1F8DE130DFBD04DE64978E7B852A7A547BE1404956A366608276D2520B678670",
+      "algorithm": "sha256"
+    },
+    {
       "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.487.0/registry.yaml",
       "checksum": "3D55277449CA3E368AB56831B8465827AB1BD110E1EB43A83B0C098B5D291A280703C285CBEC52954D8FF3944BB41F3AE93CE547082718E042590F694120DF1B",
       "algorithm": "sha512"
+    },
+    {
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.522.0/registry.yaml",
+      "checksum": "4B7CCAEC37D873A69BC72E16901CC684ECF045B5E0F3A4D7AC17E6409D7AB09E",
+      "algorithm": "sha256"
     }
   ]
 }

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -236,6 +236,26 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_darwin_amd64.tar.gz",
+      "checksum": "242D0697152D31BF04F3759EC5C55CF8CCBF47B6E2680DD24531E63A6D890468",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_darwin_arm64.tar.gz",
+      "checksum": "3260E0D6FA7D89E4B9A7CC6C120345DB9217C4E0571742E9A76DB2BA3FF63650",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_linux_amd64.tar.gz",
+      "checksum": "CC220902615325B10BD3BC52ED3DE27488F79ADAEC52ADCD12BD2194C2D2C592",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/suzuki-shunsuke/pinact/v4.0.0/pinact_linux_arm64.tar.gz",
+      "checksum": "C5D8EFB4B253A749B754AD04F484D93C78FADE5470BB549D58DF6A8AECA9B18BF",
+      "algorithm": "sha256"
+    },
+    {
       "id": "http/dl.k8s.io/v1.35.4/bin/darwin/amd64/kubectl",
       "checksum": "DDDB01BDDB96F78E48E33105CCFA2FEEDFF585A8B2E3B812F5D0F64C7403710A",
       "algorithm": "sha256"

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -13,6 +13,7 @@ registries:
 packages:
 - name: clamoriniere/crd-to-markdown@v0.0.3
 - name: dominikh/go-tools/staticcheck@2026.1
+- name: suzuki-shunsuke/pinact@v4.0.0
 - name: helm/helm@v4.2.0
 - name: kubernetes/kubectl@v1.35.4
 - name: kubernetes-sigs/controller-runtime/setup-envtest@v0.23.3

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -9,17 +9,17 @@ checksum:
   - linux
 registries:
 - type: standard
-  ref: v4.487.0 # renovate: depName=aquaproj/aqua-registry
+  ref: v4.522.0 # renovate: depName=aquaproj/aqua-registry
 packages:
 - name: clamoriniere/crd-to-markdown@v0.0.3
 - name: dominikh/go-tools/staticcheck@2026.1
-- name: helm/helm@v4.1.4
+- name: helm/helm@v4.2.0
 - name: kubernetes/kubectl@v1.35.4
 - name: kubernetes-sigs/controller-runtime/setup-envtest@v0.23.3
 - name: kubernetes-sigs/controller-tools/controller-gen@v0.20.1
 - name: kubernetes-sigs/kubebuilder@v4.13.1
 - name: kubernetes-sigs/kustomize@kustomize/v5.8.1
 - name: kubernetes-sigs/kind@v0.31.0
-- name: mikefarah/yq@v4.52.5
-- name: tilt-dev/ctlptl@v0.9.0
-- name: tilt-dev/tilt@v0.37.0
+- name: mikefarah/yq@v4.53.3
+- name: tilt-dev/ctlptl@v0.9.4
+- name: tilt-dev/tilt@v0.37.3

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/cybozu-go/nyamber
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/cybozu-go/well v1.11.2
-	github.com/onsi/ginkgo/v2 v2.28.1
-	github.com/onsi/gomega v1.39.1
+	github.com/onsi/ginkgo/v2 v2.29.0
+	github.com/onsi/gomega v1.41.0
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4

--- a/go.sum
+++ b/go.sum
@@ -98,10 +98,10 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
-github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
-github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
-github.com/onsi/gomega v1.39.1/go.mod h1:hL6yVALoTOxeWudERyfppUcZXjMwIMLnuSfruD2lcfg=
+github.com/onsi/ginkgo/v2 v2.29.0 h1:rfh+ZFjgJhYWRoIqVf3Uwx/W20yLrcrE2h2GmYVRaag=
+github.com/onsi/ginkgo/v2 v2.29.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
+github.com/onsi/gomega v1.41.0 h1:OwKp4pXNgVxf6sCplzYo794OFNuoL2q2SBMU5NSWOjA=
+github.com/onsi/gomega v1.41.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
* Updated the base images for both `Dockerfile` and `Dockerfile.runner` to use newer versions of `cybozu/golang` and `cybozu/ubuntu` (still based on Ubuntu Jammy due to a dependency requirement), and updated the bundled versions of Go and Placemat. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R3) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L22-R24) [[3]](diffhunk://#diff-1b70b5959546ac458d2b41882857b0173e22190fc13ea962852b2072dc2b8e0eL2-R3) [[4]](diffhunk://#diff-1b70b5959546ac458d2b41882857b0173e22190fc13ea962852b2072dc2b8e0eL21-R31)

CI/CD workflow improvements:

* Bumped several GitHub Actions to their latest patch or minor versions in `.github/workflows/ci.yaml`, `.github/workflows/release.yaml`, and `.github/workflows/renovate.yaml` for better security and reliability. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL66-R66) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL17-R20) [[3]](diffhunk://#diff-f87681f1c7db60655a75838d0610544d4b75e26c6909a97b97f5ec4aa323c7aaL14-R14) [[4]](diffhunk://#diff-f87681f1c7db60655a75838d0610544d4b75e26c6909a97b97f5ec4aa323c7aaL23-R23)

Tool and registry version updates:

* Updated the Aqua registry reference and multiple tool versions (such as `helm`, `yq`, `ctlptl`, and `tilt`) in `aqua.yaml` to their latest releases.
* Added corresponding new checksums for these updated tools and registry versions in `aqua-checksums.json`. [[1]](diffhunk://#diff-e06191a7d265c188e354ef4bb5078228e2a7c23453f03b9daa535c853885b212R138-R157) [[2]](diffhunk://#diff-e06191a7d265c188e354ef4bb5078228e2a7c23453f03b9daa535c853885b212R178-R197) [[3]](diffhunk://#diff-e06191a7d265c188e354ef4bb5078228e2a7c23453f03b9daa535c853885b212R218-R237) [[4]](diffhunk://#diff-e06191a7d265c188e354ef4bb5078228e2a7c23453f03b9daa535c853885b212R278-R306)