### PR TITLE
Add aqua to runner image for Neco environment setup

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -29,11 +29,14 @@ ENV GO_SHA=1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f
 # renovate: datasource=github-releases depName=cybozu-go/placemat
 ENV PLACEMAT_VERSION=2.4.11
 ENV PLACEMAT_SHA=eb32893ed824d8d009cd7214283c02b9652a460fa3a7184c47e7adbcc0f32cd2
+ENV AQUA_INSTALLER_VERSION=v4.0.5
+ENV AQUA_INSTALLER_SHA=451028d56959cc738564885b1dbebc2691ea038ffde04e2472e4d486a3591146
+ENV AQUA_VERSION=v2.60.1
 
 ENV HOME=/home/nyamber
 ENV GOPATH=${HOME}/go
 ENV GOBIN=${GOPATH}/bin
-ENV PATH=${GOBIN}:/usr/local/go/bin:${PATH}
+ENV PATH=${HOME}/.local/share/aquaproj-aqua/bin:${GOBIN}:/usr/local/go/bin:${PATH}
 ENV NECO_DIR=${GOPATH}/src/github.com/cybozu-go/neco
 ENV NECO_APPS_DIR=${GOPATH}/src/github.com/cybozu-private/neco-apps
 
@@ -86,9 +89,15 @@ RUN curl -sSLf https://cli.github.com/packages/githubcli-archive-keyring.gpg -o 
     && echo "${PLACEMAT_SHA}  placemat2.deb" | sha256sum -c - \
     && dpkg -i placemat2.deb \
     && rm placemat2.deb \
+    && curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/${AQUA_INSTALLER_VERSION}/aqua-installer \
+    && echo "${AQUA_INSTALLER_SHA}  aqua-installer" | sha256sum -c - \
+    && chmod +x aqua-installer \
+    && ./aqua-installer -v ${AQUA_VERSION} \
+    && rm ./aqua-installer \
     && echo "nyamber ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers \
     && adduser --disabled-password --gecos "" --uid 10000 nyamber \
     && chown -R nyamber:nyamber ${HOME}
+
 WORKDIR /
 COPY --from=builder /workspace/entrypoint .
 USER nyamber


### PR DESCRIPTION
Install aqua via [aqua-installer](https://aquaproj.github.io/docs/products/aqua-installer/#shell-script) into the runner image, as it is required for Neco environment setup.